### PR TITLE
Update dashboard title to mcp-testing-dashboard-3

### DIFF
--- a/grafana/new-dashboard.json
+++ b/grafana/new-dashboard.json
@@ -133,6 +133,6 @@
     },
     "timepicker": {},
     "timezone": "browser",
-    "title": "mcp-testing-dashboard-2"
+    "title": "mcp-testing-dashboard-3"
   }
 }


### PR DESCRIPTION
This PR updates the dashboard title from "mcp-testing-dashboard-2" to "mcp-testing-dashboard-3" as part of testing the GitOps workflow for dashboard management through file operations.

Changes:
- Updated spec.title field in new-dashboard.json
- Dashboard UID remains the same (adpmnwf)
- All other dashboard configuration preserved

Testing: This change demonstrates the complete GitOps workflow: File Update → Feature Branch → Pull Request → Review → Merge → Sync